### PR TITLE
#351 Change calculation of BIC use don't cares XXX as branch code in BIC

### DIFF
--- a/Source/HBCIController.m
+++ b/Source/HBCIController.m
@@ -234,7 +234,12 @@ static HBCIController *controller = nil;
     if (iban.length > 12 && [iban hasPrefix: @"DE"]) {
         BankInfo *info = [self infoForBankCode:[iban substringWithRange: NSMakeRange(4, 8)]];
         if (info) {
-            return info.bic;
+            // ToDo: check compatibility with other banks,
+            // ING-Diba doesn't accept BIC with branch code
+            // it is optional according to ISO 9362
+            NSString *tmpbic = info.bic;
+            tmpbic = [info.bic substringToIndex:8];
+            return [tmpbic stringByAppendingString:@"XXX"];
         } else {
             return nil;
         }


### PR DESCRIPTION
Dies ist ein Bugfix für #351 als ING-Diba Kunde stehe ich auch vor dem Problem, dass die automatisch errechnete BIC nicht akzeptiert wird. Lediglich BICs ohne Filialkennung oder mit 'XXX' als Filialkennung werden akzeptiert. Laut ISO9362 ist die Filialkennung optional. Bei meinen Tests konnte ich die Kennung komplett weglassen, ich bin mir jedoch unsicher wie andere Banken dies handhaben. Deswegen habe ich die Variante mit den 'XXX' bevorzugt. Bitte schaut mal drüber.