### PR TITLE
Fix for empty bank names

### DIFF
--- a/Source/BankingCategory.m
+++ b/Source/BankingCategory.m
@@ -493,7 +493,12 @@ static ShortDate *endReportDate = nil;
     if ([n isEqualToString: @"++nassroot"]) {
         return NSLocalizedString(@"AP12", nil);
     }
-    return n;
+    if (n==nil) {
+		return @"";
+	} else {
+		return n;
+	}
+
 }
 
 /**


### PR DESCRIPTION
Ich verwende ein virtuelles Konto für Forderungen. Beim Anlegen dieses Kontos habe ich mir keine großen Gedanken gemacht und für Kontonummer und BLZ irgendetwas eingegeben. Pecunia hat dafür kein Match gefunden und den Namen der entsprechenden BankingCategory auf nil gesetzt. Das führt zum Crash der Funktion createItemForAccountSelector in der PreferenceController.m damit crasht auch die awakeFromNib und die gesamte Initalisierung des Preferences-Fensters bricht ab (Icons werden nicht geladen etc.).
Mein Fix behebt dieses Problem. Mittelfristig sollte man sich evtl. überlegen, ob man beim Einrichten von Konten explizit virtuelle Konten als Möglichkeit angibt und dann die fehlenden Werte durch entsprechende Dummy-Werte auffüllt.