### PR TITLE
Lower SizeContraints of MainWindow to usable values for MacBook Pro 13.3

### DIFF
--- a/Resources/Designer/MainMenu.xib
+++ b/Resources/Designer/MainMenu.xib
@@ -18,7 +18,7 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <rect key="contentRect" x="148" y="114" width="1200" height="700"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
-            <value key="minSize" type="size" width="1300" height="750"/>
+            <value key="minSize" type="size" width="1280" height="700"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="1200" height="700"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
Die Mindestgröße ist 20 Punkte zu breit für ein 13.3er MacBook Pro. Die Mindesthöhe zwingt es auch bis hinter das Dock.