### PR TITLE
fix Exception in ResultParser.m due to missing property (DKB-Broker)

### DIFF
--- a/Source/BankQueryResult.swift
+++ b/Source/BankQueryResult.swift
@@ -40,6 +40,9 @@ import Foundation
     var bankCode: String = "";
     var accountNumber: String = "";
     var accountSuffix: String?;
+    
+    // DKB-Broker BankAccount has this in the XML, KVC in ResultParser.m needs this.
+    var currency: String = "";
 
     override init() {
         super.init();


### PR DESCRIPTION
Bei mir kommt beim Umsatzabruf für das DKB Broker Konto folgendes XML
```
<result command="getAllStatements">
    <list>
        <object type="BankQueryResult">
            <bankCode>12030000</bankCode>
            <accountNumber>12345678</accountNumber>
            <currency>EUR</currency>
            <balance type="value">xxx</balance>
        </object>
    </list>
</result>
```
`currency` fehlt im `BankQueryResult` und `ResultParser` wirft eine Exception.