### PR TITLE
fix: OSX 10.11 does not have Lucida Console

### DIFF
--- a/Plugins/PecuniaPluginTester/PecuniaPluginTester/AppDelegate.swift
+++ b/Plugins/PecuniaPluginTester/PecuniaPluginTester/AppDelegate.swift
@@ -199,7 +199,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSTableViewDataSource, JSLog
 
   // MARK: - Logging
 
-  private let logFont = NSFont(name: "LucidaConsole", size: 13);
+  private let logFont = NSFont(name: "Menlo", size: 13);
 
   @objc func logError(message: String) -> Void {
     let text = String(format: "[Error] %@\n", message);


### PR DESCRIPTION
LucidaConsole is not available on 10.11 causing
```
Fatal error: unexpectedly found nil while unwrapping an Optional values
```

Courier has been available [from 10.6](https://en.wikipedia.org/wiki/List_of_typefaces_included_with_OS_X) and still is.