### PR TITLE
Fix ING-DiBa FinTS access: bank-scoped userId check, drop forced HBCI 2.2

### DIFF
--- a/Source/BankUser.h
+++ b/Source/BankUser.h
@@ -75,7 +75,7 @@
 
 + (NSArray *)allUsers;
 + (BankUser *)findUserWithId: (NSString *)userId bankCode: (NSString *)bankCode;
-+ (BOOL)existsUserWithId:(NSString *)userId;
++ (BOOL)existsUserWithId:(NSString *)userId bankCode:(NSString *)bankCode;
 + (void)removeUser:(BankUser*)user;
 
 @end

--- a/Source/BankUser.m
+++ b/Source/BankUser.m
@@ -461,15 +461,15 @@ static NSMutableDictionary *users = nil;
     return bankUsers.lastObject;
 }
 
-+ (BOOL)existsUserWithId:(NSString *)userId
++ (BOOL)existsUserWithId:(NSString *)userId bankCode:(NSString *)bankCode
 {
     NSError *error = nil;
-    
+
     NSManagedObjectContext *context = [[MOAssistant sharedAssistant] context];
     NSEntityDescription    *entityDescription = [NSEntityDescription entityForName: @"BankUser" inManagedObjectContext: context];
     NSFetchRequest         *request = [[NSFetchRequest alloc] init];
     [request setEntity: entityDescription];
-    NSPredicate *predicate = [NSPredicate predicateWithFormat: @"userId = %@", userId];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat: @"userId = %@ AND bankCode = %@", userId, bankCode];
     [request setPredicate: predicate];
     NSArray *bankUsers = [context executeFetchRequest: request error: &error];
     if (error) {

--- a/Source/NewBankUserController.m
+++ b/Source/NewBankUserController.m
@@ -181,16 +181,13 @@
             if (currentUser.hbciVersion == nil || currentUser.hbciVersion.length == 0) {
                 currentUser.hbciVersion = @"300";
             }
-            if ([currentUser.bankCode isEqualToString:@"50010517"]) {
-                currentUser.hbciVersion = @"220";
-            }
         }
 
         if (step >= 2 ) {
             // create user
             if (bankUserCreated == NO) {
                 // first check if user with same userid already exists
-                if ([BankUser existsUserWithId:currentUser.userId]) {
+                if ([BankUser existsUserWithId:currentUser.userId bankCode:currentUser.bankCode]) {
                     NSRunAlertPanel(NSLocalizedString(@"AP839", nil),
                                     NSLocalizedString(@"AP838", nil),
                                     NSLocalizedString(@"AP1", nil), nil, nil,
@@ -317,7 +314,7 @@
             // Create User
             if (bankUserCreated == NO) {
                 // first check if user with same userid already exists
-                if ([BankUser existsUserWithId:currentUser.userId]) {
+                if ([BankUser existsUserWithId:currentUser.userId bankCode:currentUser.bankCode]) {
                     NSRunAlertPanel(NSLocalizedString(@"AP839", nil),
                                     NSLocalizedString(@"AP838", nil),
                                     NSLocalizedString(@"AP1", nil), nil, nil,


### PR DESCRIPTION
## Problem

Since ING-DiBa switched to freely chosen (often name-based) login usernames, it's become common to end up with the same `userId` across two different banks (e.g. the same value at ING-DiBa and DKB). Pecunia currently refuses this in two independent ways:

1. `+[BankUser existsUserWithId:]` checks uniqueness of `userId` **globally across all banks** instead of scoping it to `bankCode`. Creating a second Bankkennung with an already-used `userId` at a *different* bank is rejected with "Eine Bankkennung mit der Benutzerkennung ... existiert bereits", even though `userId`/`customerId` are stored per-`BankUser` and the FinTS handshake includes the bank code independently (confirmed via `Idn.customerid` in `HBCIDialog.swift` and the account-matching logic in `HBCIBackend.updateBankAccounts`, which matches purely on bank code + account number).

2. `NewBankUserController` hardcodes HBCI version `220` for bank code `50010517` (ING-DiBa) — presumably a historical workaround from before ING-DiBa properly supported FinTS 3.0. ING-DiBa now returns account statements in CAMT (ISO 20022) format, which is only defined in `hbci300.xml`, not `hbci220.xml`. With the forced 220 version this fails silently with `Segment CamtStatements is not supported by HBCI4Swift`, and ING-DiBa accounts stop receiving new statements even though the bank connection itself succeeds (login, balance queries etc. work fine).

## Fix

- `existsUserWithId:` now takes `bankCode` and scopes the uniqueness predicate to `userId + bankCode`.
- Removed the hardcoded `220` override for `50010517`; ING-DiBa now gets the normal auto-detected/fallback version (`300`) like every other bank.
- Bumped the `HBCI4Swift` submodule — the previously pinned commit predates CAMT support entirely (no `HBCICamtStatementsOrder.swift`, no CAMT segment definitions in `hbci300.xml`), so it's required for the HBCI 300 fix above to actually resolve the ING-DiBa statement retrieval problem.

## Testing

Verified locally: the same `userId` now works for both a DKB and an ING-DiBa Bankkennung at once, and ING-DiBa account statements (previously stuck since the username-login switch) synchronize again after switching to HBCI 300. Deletion of a stale/broken Bankkennung was also confirmed to leave existing accounts and statement history untouched (`BankUser.accounts` / `BankAccount.users` are `Nullify`, not `Cascade`, in the Core Data model), for anyone hitting the same issue and needing to redo a Bankkennung.

Happy to adjust anything (e.g. if there's a reason for the original 220 override I'm not aware of, or if the submodule bump should be scoped differently).